### PR TITLE
Changed the file name of the draft to include "eppext", removed the d…

### DIFF
--- a/draft-xie-eppext-nv-mapping.html
+++ b/draft-xie-eppext-nv-mapping.html
@@ -409,10 +409,10 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Jiagui, X., Gould, J., and L. Hongyan" />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-xie-epp-nv-mapping-00" />
-  <meta name="dct.issued" scheme="ISO8601" content="2015-9-27" />
-  <meta name="dct.abstract" content="This document describes an Extensible Provisioning Protocol (EPP) for the provisioning and management of Name Verification (NV) stored in a shared central repository.  Specified in XML, the mapping defines EPP command syntax and semantics as applied to name verification.  " />
-  <meta name="description" content="This document describes an Extensible Provisioning Protocol (EPP) for the provisioning and management of Name Verification (NV) stored in a shared central repository.  Specified in XML, the mapping defines EPP command syntax and semantics as applied to name verification.  " />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-xie-eppext-nv-mapping-00" />
+  <meta name="dct.issued" scheme="ISO8601" content="2015-10-4" />
+  <meta name="dct.abstract" content="This document describes an Extensible Provisioning Protocol (EPP) for the provisioning and management of Name Verification (NV) stored in a shared central repository in China.  Specified in XML, the mapping defines EPP command syntax and semantics as applied to name verification.  " />
+  <meta name="description" content="This document describes an Extensible Provisioning Protocol (EPP) for the provisioning and management of Name Verification (NV) stored in a shared central repository in China.  Specified in XML, the mapping defines EPP command syntax and semantics as applied to name verification.  " />
 
 </head>
 
@@ -434,7 +434,7 @@
   <td class="right">J. Gould</td>
 </tr>
 <tr>
-  <td class="left">Expires: March 30, 2016</td>
+  <td class="left">Expires: April 6, 2016</td>
   <td class="right">VeriSign, Inc.</td>
 </tr>
 <tr>
@@ -447,7 +447,7 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">September 27, 2015</td>
+  <td class="right">October 4, 2015</td>
 </tr>
 
     	
@@ -455,19 +455,19 @@
   </table>
 
   <p class="title">Extensible Provisioning Protocol (EPP) China Name Verification Mapping <br />
-  <span class="filename">draft-xie-epp-nv-mapping-00</span></p>
+  <span class="filename">draft-xie-eppext-nv-mapping-00</span></p>
   
   <h1 id="rfc.abstract">
   <a href="#rfc.abstract">Abstract</a>
 </h1>
-<p>This document describes an Extensible Provisioning Protocol (EPP) for the provisioning and management of Name Verification (NV) stored in a shared central repository.  Specified in XML, the mapping defines EPP command syntax and semantics as applied to name verification.  </p>
+<p>This document describes an Extensible Provisioning Protocol (EPP) for the provisioning and management of Name Verification (NV) stored in a shared central repository in China.  Specified in XML, the mapping defines EPP command syntax and semantics as applied to name verification.  </p>
 <h1 id="rfc.status">
   <a href="#rfc.status">Status of This Memo</a>
 </h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on March 30, 2016.</p>
+<p>This Internet-Draft will expire on April 6, 2016.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
@@ -516,8 +516,9 @@
   <h1 id="rfc.section.1"><a href="#rfc.section.1">1.</a> Introduction</h1>
 <p id="rfc.section.1.p.1">When creating a domain name which will be stored in a shared central repository, some registry administrative organizations require the verification of the domain name and the real name based on legal or policy requirements.  </p>
 <p id="rfc.section.1.p.2">The domain name verification, means to verify the domain label is in compliance with laws, rules and regulations.  The real name verification, means to verify that the registrant really exists and is authorized to register a domain name.  </p>
-<p id="rfc.section.1.p.3">In order to meet above requirements of the domain name registration, this document describes the Extensible Provisioning Protocol (EPP) Name Verification (NV) Mapping. This document is specified using the Extensible Markup Language (XML) 1.0 as described in <a href="#W3C.REC-xml-20040204">[W3C.REC-xml-20040204]</a> and XML Schema notation as described in <a href="#W3C.REC-xmlschema-1-20041028">[W3C.REC-xmlschema-1-20041028]</a> and <a href="#W3C.REC-xmlschema-2-20041028">[W3C.REC-xmlschema-2-20041028]</a>.  </p>
-<p id="rfc.section.1.p.4">The EPP core protocol specification <a href="#RFC5730">[RFC5730]</a> provides a complete description of EPP command and response structures. A thorough understanding of the base protocol specification is necessary to understand the mapping described in this document.  </p>
+<p id="rfc.section.1.p.3">The verification of this document meets the requirements in China, but MAY be applicable outside of China.</p>
+<p id="rfc.section.1.p.4">In order to meet above requirements of the domain name registration, this document describes the Extensible Provisioning Protocol (EPP) Name Verification (NV) Mapping. This document is specified using the Extensible Markup Language (XML) 1.0 as described in <a href="#W3C.REC-xml-20040204">[W3C.REC-xml-20040204]</a> and XML Schema notation as described in <a href="#W3C.REC-xmlschema-1-20041028">[W3C.REC-xmlschema-1-20041028]</a> and <a href="#W3C.REC-xmlschema-2-20041028">[W3C.REC-xmlschema-2-20041028]</a>.  </p>
+<p id="rfc.section.1.p.5">The EPP core protocol specification <a href="#RFC5730">[RFC5730]</a> provides a complete description of EPP command and response structures. A thorough understanding of the base protocol specification is necessary to understand the mapping described in this document.  </p>
 <h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> Terminology</h1>
 <p id="rfc.section.2.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="#RFC2119">[RFC2119]</a>.  </p>
 <p id="rfc.section.2.p.2">"nv-1.0" in this document is used as an abbreviation for urn:ietf:params:xml:ns:nv-1.0.  The XML namespace prefix "nv" is used, but implementations MUST NOT depend on it and instead employ a proper namespace-aware XML parser and serializer to interpret and output the XML documents.  </p>
@@ -532,11 +533,11 @@
   <li>Domain Name Verification(DNV), represents the verification of the domain's label is in compliance with laws, rules and regulations.  </li>
   <li>Real Name Verification(RNV), represents the verification of the registrant(real name) is in compliance with laws, rules and regulations.  </li>
   <li>Name Verification(NV), represents DNV, RNV or both of them.  </li>
-  <li>Verification Code, which is described in "verisign_epp-extension_verificationcode",is a formatted token, referred to as the Verification Code Token, that is digitally signed by a Verification Service Provider (VSP) using XML Signature in "W3C.CR-xmldsig-core2-20120124".  </li>
-  <li>Signed Code, which is described in "verisign_epp-extension_verificationcode", is the XML Signature format of the Verification Code.  </li>
-  <li>Encoded Signed Code,  which is described in "verisign_epp-extension_verificationcode", is the "base64" encoded XML Signature format of the Verification Code.  </li>
-  <li>Prohibited Name(PN),TBD.  </li>
-  <li>Reserved Name(RN),TBD.  </li>
+  <li>Verification Code, which is described in <a href="#I-D.gould-eppext-verificationcode">[I-D.gould-eppext-verificationcode]</a> ,is a formatted token, referred to as the Verification Code Token, that is digitally signed by a Verification Service Provider (VSP) using XML Signature in "W3C.CR-xmldsig-core2-20120124".  </li>
+  <li>Signed Code, which is described in <a href="#I-D.gould-eppext-verificationcode">[I-D.gould-eppext-verificationcode]</a>, is the XML Signature format of the Verification Code.  </li>
+  <li>Encoded Signed Code,  which is described in <a href="#I-D.gould-eppext-verificationcode">[I-D.gould-eppext-verificationcode]</a>, is the "base64" encoded XML Signature format of the Verification Code.  </li>
+  <li>Prohibited Name(PN), is a domain label that is prohibited from registration.  </li>
+  <li>Restricted Name(RN), is a domain label that is restricted from registration.  Additional information is needed during Domain Name Verification (DMV) to authorize the registration of a Restricted Name.  </li>
 </ul>
 
 <p> </p>
@@ -545,7 +546,7 @@
 <p/>
 
 <ul>
-  <li>Status Values.  A NV object MUST always have one associated status value. The Status value can be set only by the server.  The status value MAY be accompanied by a string of human-readable text that describes the rationale for the status applied to the object. The status of an object MAY change as a result of an action performed by a server operator.  Status Value Descriptions: <ul><li>pendingCompliant.  The object verification is not complete and is pending complete.  Please refer to section 4.3.  Offline Review of Requested Actions (reference) for details on handling offline review of of NV objects with the pendingComplaint status.  </li><li>compliant.  The object is in compliance with the policy.  </li><li>nonCompliant.  The object is not in compliance with the policy.  </li></ul><p> </p></li>
+  <li>Status Values.  A NV object MUST always have one associated status value. The Status value can be set only by the server.  The status value MAY be accompanied by a string of human-readable text that describes the rationale for the status applied to the object. The status of an object MAY change as a result of an action performed by a server operator.  Status Value Descriptions: <ul><li>pendingCompliant.  The object verification is not complete and is pending completion.  Please refer to <a href="#offlineReview">Section 4.3</a> for details on handling offline review of NV objects with the pendingComplaint status.  </li><li>compliant.  The object is in compliance with the policy.  </li><li>nonCompliant.  The object is not in compliance with the policy.  </li></ul><p> </p></li>
   <li>Dates and Times.  Date and time attribute values MUST be represented in Universal Coordinated Time (UTC) using the Gregorian calendar.  The extended date-time form using upper case "T" and "Z" characters defined in <a href="#W3C.REC-xmlschema-2-20041028">[W3C.REC-xmlschema-2-20041028]</a> MUST be used to represent date-time values, as XML Schema does not support truncated date-time forms or lower case "T" and "Z" characters.  </li>
   <li>Authorization Information.  Authorization information is associated with NV objects to facilitate query operations.  Authorization information is assigned when a NV object is created, and it might be updated in the future.  This specification describes password-based authorization information, though other mechanisms are possible.  </li>
 </ul>
@@ -640,7 +641,7 @@ S:&lt;/epp&gt;
 <p/>
 
 <ul>
-  <li>A &lt;nv:code&gt; element that contains the Verification Code Token value.  An "type" attribute MUST be used to identify the type of the query(Signed Code or Input Data).  If the type is "signedCode",the response of the server MUST be the Signed Code of the verification code.  If the type is "input",the response of the server MUST be the verification input data and the verification status.  </li>
+  <li>A &lt;nv:code&gt; element that contains the Verification Code Token value.  An "type" attribute MUST be used to identify the type of the query(Signed Code or Input Data).  If the type is "signedCode", the successful response of the server MUST be the Signed Code of the verification code.  If the type is "input", the successful response of the server MUST be the verification input data and the verification status.  </li>
   <li>An OPTIONAL &lt;nv:authInfo&gt; element that contains authorization information associated with the NV object. If this element is not provided or if the authorization information is invalid, server policy determines if the command is rejected or if response information will be returned to the client.  </li>
 </ul>
 
@@ -700,7 +701,7 @@ C:&lt;/epp&gt;
 <ul>
   <li>A &lt;nv:code&gt; element that contains the Verification Code Token value of the signed code with the "type" attribute to indicate the type of NV object.  The "type" attribute value of "domain" indicates a DNV object and "real-name" indicates a RNV object.  </li>
   <li>An &lt;nv:status&gt; elements that contain the current status associated with the NV.  </li>
-  <li>A &lt;verificationCode:encodedSignedCode&gt; element include: <ul><li>A &lt;verificationCode:code&gt;element that is an "base64" encoded form of the digitally signed &lt;verificationCode:signedCode&gt;.  </li></ul><p> </p></li>
+  <li>A &lt;nv:encodedSignedCode&gt; element include: <ul><li>A &lt;verificationCode:code&gt;element that is an "base64" encoded form of the digitally signed &lt;verificationCode:signedCode&gt; as defined in <a href="#I-D.gould-eppext-verificationcode">[I-D.gould-eppext-verificationcode]</a>.  </li></ul><p> </p></li>
 </ul>
 
 <p> </p>
@@ -800,7 +801,7 @@ C:&lt;/epp&gt;
 
 <ul>
   <li>A &lt;nv:name&gt; element that contains the label of the domain.  </li>
-  <li>An OPTIONAL &lt;nv:rnvCode&gt; element containing the Verification Code Token value of a RNV object used for verification of a Reserved Name.  </li>
+  <li>An OPTIONAL &lt;nv:rnvCode&gt; element containing the Verification Code Token value of a RNV object used for verification of a Restricted Name.  </li>
 </ul>
 
 <p> </p>
@@ -924,7 +925,7 @@ S:&lt;/epp&gt;
 <p id="rfc.section.4.2.1.p.1">The EPP &lt;create&gt; command provides a transform operation that allows a client to create an NV object.  In addition to the standard EPP command elements, the &lt;create&gt; command MUST contain a &lt;nv:create&gt; element that identifies the NV namespace.  The &lt;nv:create&gt; elements contains a choice of two different child elements dependent on the type of NV object to create.  The &lt;nv:dnv&gt; child element is used to create a DNV object and the &lt;nv:rnv&gt; child element is used to create a RNV object.  AN &lt;nv:authInfo&gt; element contains authorization information to be associated with the NV object.  </p>
 
 <ul>
-  <li>The &lt;nv:dnv&gt; element is used for a DNV object and contains the following child elements: <ul><li>A &lt;nv:name&gt; element that contains the label of the domain.  </li><li>An OPTIONAL &lt;nv:rnvCode&gt; element containing the Verification Code Token value of a RNV object used for verification of a Reserved Name.  </li></ul><p> </p></li>
+  <li>The &lt;nv:dnv&gt; element is used for a DNV object and contains the following child elements: <ul><li>A &lt;nv:name&gt; element that contains the label of the domain.  </li><li>An OPTIONAL &lt;nv:rnvCode&gt; element containing the Verification Code Token value of a RNV object used for verification of a Restricted Name.  </li></ul><p> </p></li>
   <li>The &lt;nv:rnv&gt; element is used for a RNV object.  The "role" attribute MUST be used to identify the role of the RNV object with the possible values of "person" or "organization".  The &lt;nv:rnv&gt; element contains the following child elements: <ul><li>A &lt;nv:name&gt; element that contains the full name of the contact.  </li><li>A &lt;nv:num&gt; element that contains the citizen or the organization ID of the contact.  </li><li>A &lt;nv:proofType&gt; element that contains the proof material type of the of the contact.  </li><li>Zero or more &lt;nv:document&gt; element that contains the following child elements: <ul><li>A &lt;nv:fileType&gt; element contains the type of the file.  </li><li>A &lt;nv:fileContent&gt; element contains the "base64" encoded content of the file.  </li></ul><p> </p></li></ul><p> </p></li>
 </ul>
 
@@ -1005,7 +1006,7 @@ C:&lt;/epp&gt;
 <p/>
 
 <ul>
-  <li>The &lt;nv:success&gt; element contains the following child elements: <ul><li>A &lt;nv:code&gt; element that contains the id of the verification code with the required "type" attribute that defines the type of the verification code.  </li><li>Zero or more OPTIONAL &lt;nv:status&gt; elements that contain the current status descriptors associated with the NV.  </li><li>A  &lt;nv:crDate&gt; element that contains the date and time of nv object creation.  </li><li>A &lt;verificationCode:encodedSignedCode&gt; element include: <ul><li>A &lt;verificationCode:code&gt;element that is an "base64" encoded form of the digitally signed &lt;verificationCode:signedCode&gt;.  </li></ul><p> </p></li></ul><p> </p></li>
+  <li>The &lt;nv:success&gt; element contains the following child elements: <ul><li>A &lt;nv:code&gt; element that contains the id of the verification code with the required "type" attribute that defines the type of the verification code.  </li><li>Zero or more OPTIONAL &lt;nv:status&gt; elements that contain the current status descriptors associated with the NV.  </li><li>A  &lt;nv:crDate&gt; element that contains the date and time of nv object creation.  </li><li>A &lt;nv:encodedSignedCode&gt; element include: <ul><li>A &lt;verificationCode:code&gt;element that is an "base64" encoded form of the digitally signed &lt;verificationCode:signedCode&gt; as defined in <a href="#I-D.gould-eppext-verificationcode">[I-D.gould-eppext-verificationcode]</a>.  </li></ul><p> </p></li></ul><p> </p></li>
   <li>The &lt;nv:failed&gt; element contains the following child elements: <ul><li>Zero or more OPTIONAL &lt;nv:status&gt; elements that contain the current status descriptors associated with the NV.  </li><li>A &lt;nv:msg&gt; element containing a human-readable description of the reason of the failure.  The language of the response is identified via an OPTIONAL "lang" attribute.  If not specified, the default attribute value MUST be "en" (English).  </li></ul><p> </p></li>
 </ul>
 
@@ -1185,7 +1186,7 @@ S:&lt;/epp&gt;
    An EPP error response MUST be returned if an &lt;update&gt; 
    command cannot be processed for any reason.
     	</pre>
-<h1 id="rfc.section.4.3"><a href="#rfc.section.4.3">4.3.</a> Offline Review of Requested Actions</h1>
+<h1 id="rfc.section.4.3"><a href="#rfc.section.4.3">4.3.</a> <a href="#offlineReview" id="offlineReview">Offline Review of Requested Actions</a></h1>
 <p id="rfc.section.4.3.p.1">Commands are processed by a server in the order they are received from a client.  Though an immediate response confirming receipt and processing of the command is produced by the server, a server operator MAY perform an offline review of requested transform commands before completing the requested action.  In such situations, the response from the server MUST clearly note that the transform command has been received and processed but that the requested action is pending.  The status of the corresponding object MUST clearly reflect processing of the pending action.  The server MUST notify the client when offline processing of the action has been completed.  </p>
 <p id="rfc.section.4.3.p.2">Examples describing a &lt;create&gt; command that requires offline review are included here.  Note the result code and message returned in response to the &lt;create&gt; command.  </p>
 <pre>     
@@ -1621,6 +1622,12 @@ End of schema.
 <h1 id="rfc.references"><a href="#rfc.references">11.</a> Normative References</h1>
 <table>
   <tbody>
+    <tr>
+      <td class="reference">
+        <b id="I-D.gould-eppext-verificationcode">[I-D.gould-eppext-verificationcode]</b>
+      </td>
+      <td class="top"><a>Gould, J.</a>, "<a href="http://tools.ietf.org/html/draft-gould-eppext-verificationcode-00">Verification Code Extension for the Extensible Provisioning Protocol (EPP)</a>", Internet-Draft draft-gould-eppext-verificationcode-00, September 2015.</td>
+    </tr>
     <tr>
       <td class="reference">
         <b id="RFC2119">[RFC2119]</b>

--- a/draft-xie-eppext-nv-mapping.txt
+++ b/draft-xie-eppext-nv-mapping.txt
@@ -5,21 +5,22 @@
 Internet Engineering Task Force                                X. Jiagui
 Internet-Draft                                                  Teleinfo
 Intended status: Informational                                  J. Gould
-Expires: March 30, 2016                                   VeriSign, Inc.
+Expires: April 6, 2016                                    VeriSign, Inc.
                                                               L. Hongyan
                                                                 Teleinfo
-                                                      September 27, 2015
+                                                         October 4, 2015
 
 
  Extensible Provisioning Protocol (EPP) China Name Verification Mapping
-                      draft-xie-epp-nv-mapping-00
+                     draft-xie-eppext-nv-mapping-00
 
 Abstract
 
    This document describes an Extensible Provisioning Protocol (EPP) for
    the provisioning and management of Name Verification (NV) stored in a
-   shared central repository.  Specified in XML, the mapping defines EPP
-   command syntax and semantics as applied to name verification.
+   shared central repository in China.  Specified in XML, the mapping
+   defines EPP command syntax and semantics as applied to name
+   verification.
 
 Status of This Memo
 
@@ -36,7 +37,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 30, 2016.
+   This Internet-Draft will expire on April 6, 2016.
 
 Copyright Notice
 
@@ -49,15 +50,15 @@ Copyright Notice
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
-   include Simplified BSD License text as described in Section 4.e of
 
 
 
-Jiagui, et al.           Expires March 30, 2016                 [Page 1]
+Jiagui, et al.            Expires April 6, 2016                 [Page 1]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
+   include Simplified BSD License text as described in Section 4.e of
    the Trust Legal Provisions and are provided without warranty as
    described in the Simplified BSD License.
 
@@ -81,37 +82,36 @@ Table of Contents
      3.1.  Definitions . . . . . . . . . . . . . . . . . . . . . . .   4
      3.2.  Object Attributes . . . . . . . . . . . . . . . . . . . .   4
      3.3.  Name Verification Proofs  . . . . . . . . . . . . . . . .   5
-   4.  EPP Command Mapping . . . . . . . . . . . . . . . . . . . . .   5
+   4.  EPP Command Mapping . . . . . . . . . . . . . . . . . . . . .   6
      4.1.  EPP Query Commands  . . . . . . . . . . . . . . . . . . .   6
        4.1.1.  EPP <check> Command . . . . . . . . . . . . . . . . .   6
        4.1.2.  EPP <info> Command  . . . . . . . . . . . . . . . . .   8
-       4.1.3.  EPP <transfer> Command  . . . . . . . . . . . . . . .  15
-     4.2.  EPP Transform Commands  . . . . . . . . . . . . . . . . .  15
-       4.2.1.  EPP <create> Command  . . . . . . . . . . . . . . . .  15
-       4.2.2.  EPP <delete> Command  . . . . . . . . . . . . . . . .  21
-       4.2.3.  EPP <renew> Command . . . . . . . . . . . . . . . . .  21
-       4.2.4.  EPP <transfer> Command  . . . . . . . . . . . . . . .  21
-       4.2.5.  EPP <update> Command  . . . . . . . . . . . . . . . .  21
-     4.3.  Offline Review of Requested Actions . . . . . . . . . . .  22
-   5.  Formal Syntax . . . . . . . . . . . . . . . . . . . . . . . .  24
-   6.  Internationalization Considerations . . . . . . . . . . . . .  31
-   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  31
-     7.1.  XML Namespace . . . . . . . . . . . . . . . . . . . . . .  31
-     7.2.  EPP Extension Registry  . . . . . . . . . . . . . . . . .  32
-   8.  Security considerations . . . . . . . . . . . . . . . . . . .  32
-   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  33
-   10. Change History  . . . . . . . . . . . . . . . . . . . . . . .  33
-     10.1.  draft-xie-epp-nv-mapping-00: Version 00  . . . . . . . .  33
-   11. Normative References  . . . . . . . . . . . . . . . . . . . .  33
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  34
+       4.1.3.  EPP <transfer> Command  . . . . . . . . . . . . . . .  16
+     4.2.  EPP Transform Commands  . . . . . . . . . . . . . . . . .  16
+       4.2.1.  EPP <create> Command  . . . . . . . . . . . . . . . .  16
+       4.2.2.  EPP <delete> Command  . . . . . . . . . . . . . . . .  22
+       4.2.3.  EPP <renew> Command . . . . . . . . . . . . . . . . .  22
+       4.2.4.  EPP <transfer> Command  . . . . . . . . . . . . . . .  22
+       4.2.5.  EPP <update> Command  . . . . . . . . . . . . . . . .  22
+     4.3.  Offline Review of Requested Actions . . . . . . . . . . .  23
+   5.  Formal Syntax . . . . . . . . . . . . . . . . . . . . . . . .  25
+   6.  Internationalization Considerations . . . . . . . . . . . . .  32
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  32
+     7.1.  XML Namespace . . . . . . . . . . . . . . . . . . . . . .  32
+     7.2.  EPP Extension Registry  . . . . . . . . . . . . . . . . .  33
+   8.  Security considerations . . . . . . . . . . . . . . . . . . .  33
+   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  34
+   10. Change History  . . . . . . . . . . . . . . . . . . . . . . .  34
+     10.1.  draft-xie-epp-nv-mapping-00: Version 00  . . . . . . . .  34
+   11. Normative References  . . . . . . . . . . . . . . . . . . . .  34
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  35
 
 
 
 
-
-Jiagui, et al.           Expires March 30, 2016                 [Page 2]
+Jiagui, et al.            Expires April 6, 2016                 [Page 2]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
 1.  Introduction
@@ -125,6 +125,9 @@ Internet-Draft               EPP NV Mapping               September 2015
    compliance with laws, rules and regulations.  The real name
    verification, means to verify that the registrant really exists and
    is authorized to register a domain name.
+
+   The verification of this document meets the requirements in China,
+   but MAY be applicable outside of China.
 
    In order to meet above requirements of the domain name registration,
    this document describes the Extensible Provisioning Protocol (EPP)
@@ -162,12 +165,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-
-
-
-Jiagui, et al.           Expires March 30, 2016                 [Page 3]
+Jiagui, et al.            Expires April 6, 2016                 [Page 3]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
 3.  Definitions and Object Attributes
@@ -185,23 +185,27 @@ Internet-Draft               EPP NV Mapping               September 2015
 
    o  Name Verification(NV), represents DNV, RNV or both of them.
 
-   o  Verification Code, which is described in "verisign_epp-
-      extension_verificationcode",is a formatted token, referred to as
-      the Verification Code Token, that is digitally signed by a
-      Verification Service Provider (VSP) using XML Signature in
-      "W3C.CR-xmldsig-core2-20120124".
+   o  Verification Code, which is described in
+      [I-D.gould-eppext-verificationcode] ,is a formatted token,
+      referred to as the Verification Code Token, that is digitally
+      signed by a Verification Service Provider (VSP) using XML
+      Signature in "W3C.CR-xmldsig-core2-20120124".
 
-   o  Signed Code, which is described in "verisign_epp-
-      extension_verificationcode", is the XML Signature format of the
-      Verification Code.
+   o  Signed Code, which is described in
+      [I-D.gould-eppext-verificationcode], is the XML Signature format
+      of the Verification Code.
 
-   o  Encoded Signed Code, which is described in "verisign_epp-
-      extension_verificationcode", is the "base64" encoded XML Signature
-      format of the Verification Code.
+   o  Encoded Signed Code, which is described in
+      [I-D.gould-eppext-verificationcode], is the "base64" encoded XML
+      Signature format of the Verification Code.
 
-   o  Prohibited Name(PN),TBD.
+   o  Prohibited Name(PN), is a domain label that is prohibited from
+      registration.
 
-   o  Reserved Name(RN),TBD.
+   o  Restricted Name(RN), is a domain label that is restricted from
+      registration.  Additional information is needed during Domain Name
+      Verification (DMV) to authorize the registration of a Restricted
+      Name.
 
 3.2.  Object Attributes
 
@@ -214,23 +218,23 @@ Internet-Draft               EPP NV Mapping               September 2015
 
    o  Status Values.  A NV object MUST always have one associated status
       value.  The Status value can be set only by the server.  The
+
+
+
+Jiagui, et al.            Expires April 6, 2016                 [Page 4]
+
+Internet-Draft               EPP NV Mapping                 October 2015
+
+
       status value MAY be accompanied by a string of human-readable text
       that describes the rationale for the status applied to the object.
       The status of an object MAY change as a result of an action
       performed by a server operator.  Status Value Descriptions:
 
-
-
-Jiagui, et al.           Expires March 30, 2016                 [Page 4]
-
-Internet-Draft               EPP NV Mapping               September 2015
-
-
       *  pendingCompliant.  The object verification is not complete and
-         is pending complete.  Please refer to section 4.3.  Offline
-         Review of Requested Actions (reference) for details on handling
-         offline review of of NV objects with the pendingComplaint
-         status.
+         is pending completion.  Please refer to Section 4.3 for details
+         on handling offline review of NV objects with the
+         pendingComplaint status.
 
       *  compliant.  The object is in compliance with the policy.
 
@@ -268,19 +272,22 @@ Internet-Draft               EPP NV Mapping               September 2015
    o  Proof of Other Types(POOT),in this document the POOT represents
       other certificate materials except the POC and POE.
 
+
+
+
+
+
+Jiagui, et al.            Expires April 6, 2016                 [Page 5]
+
+Internet-Draft               EPP NV Mapping                 October 2015
+
+
 4.  EPP Command Mapping
 
    A detailed description of the EPP syntax and semantics can be found
    in the EPP core protocol specification [RFC5730].  The command
    mappings described here are specifically for use in provisioning and
    managing NV via EPP.
-
-
-
-Jiagui, et al.           Expires March 30, 2016                 [Page 5]
-
-Internet-Draft               EPP NV Mapping               September 2015
-
 
 4.1.  EPP Query Commands
 
@@ -324,20 +331,19 @@ Internet-Draft               EPP NV Mapping               September 2015
    identifies the NV namespace.  The <nv:chkData> element contains one
    or more <nv:cd>elements that contain the following child elements:
 
+
+
+Jiagui, et al.            Expires April 6, 2016                 [Page 6]
+
+Internet-Draft               EPP NV Mapping                 October 2015
+
+
    o  A <nv:name> element that contains the queried domain label.  This
       element MUST contain an "avail" attribute whose value indicates
       object availability (can it be created or not) at the moment the
       <check> command was completed.  A value of "1" or "true" means
       that the object can be created.  A value of "0" or "false" means
       that the object can not be created.  This element SHOULD contain
-
-
-
-Jiagui, et al.           Expires March 30, 2016                 [Page 6]
-
-Internet-Draft               EPP NV Mapping               September 2015
-
-
       an "restricted" attribute whose value indicates this name is an RN
       or not, with a default value of "0".  A value of "1" or "true"
       means that the object is an RN Name.  A value of "0" or "false"
@@ -351,6 +357,42 @@ Internet-Draft               EPP NV Mapping               September 2015
       attribute MAY be present to identify the language if the
       negotiated value is something other than the default value of "en"
       (English).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jiagui, et al.            Expires April 6, 2016                 [Page 7]
+
+Internet-Draft               EPP NV Mapping                 October 2015
+
 
       Example <check> response:
 
@@ -385,15 +427,6 @@ Internet-Draft               EPP NV Mapping               September 2015
    An EPP error response MUST be returned if an <check> command cannot
    be processed for any reason.
 
-
-
-
-
-Jiagui, et al.           Expires March 30, 2016                 [Page 7]
-
-Internet-Draft               EPP NV Mapping               September 2015
-
-
 4.1.2.  EPP <info> Command
 
    The EPP <info> command is used to retrieve information associated
@@ -407,6 +440,16 @@ Internet-Draft               EPP NV Mapping               September 2015
    the client does not provide valid authorization information, server
    policy determines which OPTIONAL elements are returned.
 
+
+
+
+
+
+Jiagui, et al.            Expires April 6, 2016                 [Page 8]
+
+Internet-Draft               EPP NV Mapping                 October 2015
+
+
    In addition to the standard EPP command elements, the <info> command
    MUST contain a <nv:info> element that identifies the NV namespace.
    The <nv:info> element contains the following child elements:
@@ -414,10 +457,10 @@ Internet-Draft               EPP NV Mapping               September 2015
    o  A <nv:code> element that contains the Verification Code Token
       value.  An "type" attribute MUST be used to identify the type of
       the query(Signed Code or Input Data).  If the type is
-      "signedCode",the response of the server MUST be the Signed Code of
-      the verification code.  If the type is "input",the response of the
-      server MUST be the verification input data and the verification
-      status.
+      "signedCode", the successful response of the server MUST be the
+      Signed Code of the verification code.  If the type is "input", the
+      successful response of the server MUST be the verification input
+      data and the verification status.
 
    o  An OPTIONAL <nv:authInfo> element that contains authorization
       information associated with the NV object.  If this element is not
@@ -445,9 +488,22 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                 [Page 8]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jiagui, et al.            Expires April 6, 2016                 [Page 9]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
       Example <info> command to query the signed code:
@@ -501,9 +557,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                 [Page 9]
+Jiagui, et al.            Expires April 6, 2016                [Page 10]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
    When an <info> command has been processed successfully, the EPP
@@ -525,10 +581,11 @@ Internet-Draft               EPP NV Mapping               September 2015
    o  An <nv:status> elements that contain the current status associated
       with the NV.
 
-   o  A <verificationCode:encodedSignedCode> element include:
+   o  A <nv:encodedSignedCode> element include:
 
       *  A <verificationCode:code>element that is an "base64" encoded
-         form of the digitally signed <verificationCode:signedCode>.
+         form of the digitally signed <verificationCode:signedCode> as
+         defined in [I-D.gould-eppext-verificationcode].
 
 
       Example <info> response of a Signed Code:
@@ -553,15 +610,15 @@ Internet-Draft               EPP NV Mapping               September 2015
     S:bDpuczp2ZXJpZmljYXRpb25Db2RlLTEuMCIKICAgICAgICAgIGlkPSJzaWduZWRD
     S:b2RlIj4KICAgCQk8dmVyaWZpY2F0aW9uQ29kZTpjb2RlPjEtYWJjMTIzPC92ZXJp
     S:ZmljYXRpb25Db2RlOmNvZGU+CiAgPFNpZ25hdHVyZSB4bWxucz0iaHR0cDovL3d3
-    S:dy53My5vcmcvMjAwMC8wOS94bWxkc2lnIyI+CiAgIDxTaWduZWRJbmZvPgogICAg
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 10]
+Jiagui, et al.            Expires April 6, 2016                [Page 11]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
+    S:dy53My5vcmcvMjAwMC8wOS94bWxkc2lnIyI+CiAgIDxTaWduZWRJbmZvPgogICAg
     S:PENhbm9uaWNhbGl6YXRpb25NZXRob2QKIEFsZ29yaXRobT0iaHR0cDovL3d3dy53
     S:My5vcmcvMjAwMS8xMC94bWwtZXhjLWMxNG4jIi8+CiAgICA8U2lnbmF0dXJlTWV0
     S:aG9kCiBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZHNp
@@ -609,15 +666,15 @@ Internet-Draft               EPP NV Mapping               September 2015
     S:MnFTeTd1aSs0M2NlYktVS3dXUHJ6ejl5LwogSWtyTWVKR0tqbzQwbis5dWVrYXcz
     S:REo1RXFpT2YvcVo0cGpCRCsrb1I2QkpDYjZOUXVRS3dub0F6NWxFNFNzdQogeTUr
     S:aTkzb1QzSGZ5VmM0Z05NSW9IbTFQUzE5bDdEQktyYndiekFlYS8waktXVnpydm1W
-    S:N1RCZmp4RDNBUW8xUgogYlU1ZEJyNklqYmRMRmxuTzV4MEcwbXJHN3g1T1VQdXVy
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 11]
+Jiagui, et al.            Expires April 6, 2016                [Page 12]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
+    S:N1RCZmp4RDNBUW8xUgogYlU1ZEJyNklqYmRMRmxuTzV4MEcwbXJHN3g1T1VQdXVy
     S:aWh5aVVScEZEcHdIOEtBSDF3TWNDcFhHWEZSdEdLawogd3lkZ3lWWUF0eTdvdGts
     S:L3ozYlprQ1ZUMzRnUHZGNzBzUjYrUXhVeTh1MEx6RjVBL2JlWWFacHhTWUczMWFt
     S:TAogQWRYaXRUV0ZpcGFJR2VhOWxFR0ZNMEw5K0JnN1h6Tm40blZMWG9reUVCM2Jn
@@ -648,7 +705,7 @@ Internet-Draft               EPP NV Mapping               September 2015
    o  A <nv:name> element that contains the label of the domain.
 
    o  An OPTIONAL <nv:rnvCode> element containing the Verification Code
-      Token value of a RNV object used for verification of a Reserved
+      Token value of a RNV object used for verification of a Restricted
       Name.
 
 
@@ -668,10 +725,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-
-Jiagui, et al.           Expires March 30, 2016                [Page 12]
+Jiagui, et al.            Expires April 6, 2016                [Page 13]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
       Example <info> response of a DNV:
@@ -725,9 +781,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 13]
+Jiagui, et al.            Expires April 6, 2016                [Page 14]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
       Example <info> response of an RNV person:
@@ -781,9 +837,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 14]
+Jiagui, et al.            Expires April 6, 2016                [Page 15]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
    S:         <nv:proofType>poe</nv:proofType>
@@ -837,9 +893,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 15]
+Jiagui, et al.            Expires April 6, 2016                [Page 16]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
    a RNV object.  AN <nv:authInfo> element contains authorization
@@ -852,7 +908,7 @@ Internet-Draft               EPP NV Mapping               September 2015
 
       *  An OPTIONAL <nv:rnvCode> element containing the Verification
          Code Token value of a RNV object used for verification of a
-         Reserved Name.
+         Restricted Name.
 
    o  The <nv:rnv> element is used for a RNV object.  The "role"
       attribute MUST be used to identify the role of the RNV object with
@@ -893,9 +949,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 16]
+Jiagui, et al.            Expires April 6, 2016                [Page 17]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
    C:    <clTRID>ABC-12345</clTRID>
@@ -949,9 +1005,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 17]
+Jiagui, et al.            Expires April 6, 2016                [Page 18]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
    C:         <nv:pw>2fooBAR</nv:pw>
@@ -980,10 +1036,11 @@ Internet-Draft               EPP NV Mapping               September 2015
       *  A <nv:crDate> element that contains the date and time of nv
          object creation.
 
-      *  A <verificationCode:encodedSignedCode> element include:
+      *  A <nv:encodedSignedCode> element include:
 
          +  A <verificationCode:code>element that is an "base64" encoded
-            form of the digitally signed <verificationCode:signedCode>.
+            form of the digitally signed <verificationCode:signedCode>
+            as defined in [I-D.gould-eppext-verificationcode].
 
    o  The <nv:failed> element contains the following child elements:
 
@@ -1001,15 +1058,15 @@ Internet-Draft               EPP NV Mapping               September 2015
    S:<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
    S:  <response>
    S:    <result code="1000">
-   S:      <msg>Command completed successfully</msg>
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 18]
+Jiagui, et al.            Expires April 6, 2016                [Page 19]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
+   S:      <msg>Command completed successfully</msg>
    S:    </result>
    S:    <resData>
    S:      <nv:creData xmlns:nv="urn:ietf:params:xml:ns:nv-1.0">
@@ -1057,15 +1114,15 @@ Internet-Draft               EPP NV Mapping               September 2015
    S:NGV2YlVwZWtKNWJ1cVUxZ21ReU9zQ0tRbGhPSFRkUGp2a0M1dQogcERxYTUxRmxr
    S:MFRNYU1rSVFqczdhVUtDbUE0Ukc0dFRUR0svRWpSMWl4OC9EMGdIWVZSbGR5MVlQ
    S:ck1QK291NwogNWJPVm5Jb3MrSGlmckF0ckl2NHFFcXdMTDRGVFpBVXBhQ2EyQm1n
-   S:WGZ5MkNTUlFieEQ1T3IxZ2NTYTN2dXJoNQogc1BNQ054cWFYbUlYbVFpcFMrRHVF
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 19]
+Jiagui, et al.            Expires April 6, 2016                [Page 20]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
+   S:WGZ5MkNTUlFieEQ1T3IxZ2NTYTN2dXJoNQogc1BNQ054cWFYbUlYbVFpcFMrRHVF
    S:QnFNTTh0bGRhTjdSWW9qVUVLckdWc05rNWk5eTIvN3NqbjF6eXlVUGY3dgogTDRH
    S:Z0RZcWhKWVdWNjFEblhneC9KZDZDV3h2c25ERjZzY3NjUXpVVEVsK2h5d0lEQVFB
    S:Qm80SC9NSUg4TUF3RwogQTFVZEV3RUIvd1FDTUFBd0hRWURWUjBPQkJZRUZQWkVj
@@ -1113,15 +1170,15 @@ Internet-Draft               EPP NV Mapping               September 2015
    S:      </nv:failed>
    S:     </nv:creData>
    S:    </resData>
-   S:    <trID>
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 20]
+Jiagui, et al.            Expires April 6, 2016                [Page 21]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
+   S:    <trID>
    S:      <clTRID>ABC-12345</clTRID>
    S:      <svTRID>54321-XYZ</svTRID>
    S:    </trID>
@@ -1172,10 +1229,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-
-Jiagui, et al.           Expires March 30, 2016                [Page 21]
+Jiagui, et al.            Expires April 6, 2016                [Page 22]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
       Example <update> command:
@@ -1229,9 +1285,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 22]
+Jiagui, et al.            Expires April 6, 2016                [Page 23]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
    the response from the server MUST clearly note that the transform
@@ -1285,9 +1341,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 23]
+Jiagui, et al.            Expires April 6, 2016                [Page 24]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
       A <nv:paStatus> element that contains the current status
@@ -1341,9 +1397,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 24]
+Jiagui, et al.            Expires April 6, 2016                [Page 25]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
       BEGIN
@@ -1397,9 +1453,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 25]
+Jiagui, et al.            Expires April 6, 2016                [Page 26]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
    <complexType name="createType">
@@ -1453,9 +1509,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 26]
+Jiagui, et al.            Expires April 6, 2016                [Page 27]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
    </simpleType>
@@ -1509,9 +1565,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 27]
+Jiagui, et al.            Expires April 6, 2016                [Page 28]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
    <!--
@@ -1565,9 +1621,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 28]
+Jiagui, et al.            Expires April 6, 2016                [Page 29]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
          <attribute name="avail" type="boolean"
@@ -1621,9 +1677,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 29]
+Jiagui, et al.            Expires April 6, 2016                [Page 30]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
     <sequence>
@@ -1677,9 +1733,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 30]
+Jiagui, et al.            Expires April 6, 2016                [Page 31]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
          <attribute name="s" type="nv:statusValueType"
@@ -1733,9 +1789,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 31]
+Jiagui, et al.            Expires April 6, 2016                [Page 32]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
    o  Registrant Contact: See the "Author's Address" section of this
@@ -1789,9 +1845,9 @@ Internet-Draft               EPP NV Mapping               September 2015
 
 
 
-Jiagui, et al.           Expires March 30, 2016                [Page 32]
+Jiagui, et al.            Expires April 6, 2016                [Page 33]
 
-Internet-Draft               EPP NV Mapping               September 2015
+Internet-Draft               EPP NV Mapping                 October 2015
 
 
 9.  Acknowledgements
@@ -1809,6 +1865,11 @@ Internet-Draft               EPP NV Mapping               September 2015
    o  First draft.
 
 11.  Normative References
+
+   [I-D.gould-eppext-verificationcode]
+              Gould, J., "Verification Code Extension for the Extensible
+              Provisioning Protocol (EPP)", draft-gould-eppext-
+              verificationcode-00 (work in progress), September 2015.
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119, March 1997.
@@ -1836,19 +1897,20 @@ Internet-Draft               EPP NV Mapping               September 2015
               1-20041028", October 2004,
               <http://www.w3.org/TR/2004/REC-xmlschema-1-20041028>.
 
+
+
+
+
+Jiagui, et al.            Expires April 6, 2016                [Page 34]
+
+Internet-Draft               EPP NV Mapping                 October 2015
+
+
    [W3C.REC-xmlschema-2-20041028]
               Biron, P. and A. Malhotra, ""XML Schema Part 2: Datatypes
               Second Edition", World Wide Web Consortium Recommendation
               REC-xmlschema-2-20041028", October 2004,
               <http://www.w3.org/TR/2004/REC-xmlschema-2-20041028>.
-
-
-
-
-Jiagui, et al.           Expires March 30, 2016                [Page 33]
-
-Internet-Draft               EPP NV Mapping               September 2015
-
 
 Authors' Addresses
 
@@ -1895,10 +1957,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-Jiagui, et al.           Expires March 30, 2016                [Page 34]
+Jiagui, et al.            Expires April 6, 2016                [Page 35]

--- a/draft-xie-eppext-nv-mapping.xml
+++ b/draft-xie-eppext-nv-mapping.xml
@@ -5,6 +5,8 @@
 <!ENTITY RFC3688 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3688.xml">
 <!ENTITY RFC5730 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5730.xml">
 <!ENTITY RFC7451 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7451.xml">
+<!ENTITY I-D.gould-eppext-verificationcode PUBLIC ''
+   'http://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.gould-eppext-verificationcode.xml'>
 ]>
 
 <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
@@ -16,7 +18,7 @@
 <?rfc compact="yes" ?>
 <?rfc subcompact="no" ?>
 
-<rfc category="info" docName="draft-xie-epp-nv-mapping-00" ipr="pre5378Trust200902">
+<rfc category="info" docName="draft-xie-eppext-nv-mapping-00" ipr="pre5378Trust200902">
   <!-- category values: std, bcp, info, exp, and historic -->
 
   <front>
@@ -76,7 +78,7 @@ Extensible Provisioning Protocol (EPP) China Name Verification Mapping
       </address>
     </author>       
                
-    <date month="September" year="2015" />
+    <date day="4" month="October" year="2015"/>
 
     <area>Internet</area>
 
@@ -88,7 +90,7 @@ Extensible Provisioning Protocol (EPP) China Name Verification Mapping
       <t>
 This document describes an Extensible Provisioning Protocol (EPP)
 for the provisioning and management of Name Verification (NV) stored in a shared
-central repository.  Specified in XML, the mapping defines EPP command 
+central repository in China.  Specified in XML, the mapping defines EPP command 
 syntax and semantics as applied to name verification.
       </t>
     </abstract>
@@ -107,6 +109,7 @@ The domain name verification, means to verify the domain label is in
 compliance with laws, rules and regulations.  The real name
 verification, means to verify that the registrant really exists and is authorized to register a domain name.			
       </t>
+<t>The verification of this document meets the requirements in China, but MAY be applicable outside of China.</t>  
       <t>
 In order to meet above requirements of the domain name registration, this document describes the 
 Extensible Provisioning Protocol (EPP) Name Verification (NV) Mapping. This document is specified 
@@ -169,26 +172,28 @@ Name Verification(NV), represents DNV, RNV or both of them.
             </t>	
 
 <t>
-Verification Code, which is described in "verisign_epp-extension_verificationcode",is 
+Verification Code, which is described in <xref target="I-D.gould-eppext-verificationcode"/> ,is 
 a formatted token, referred to as the Verification Code Token, 
 that is digitally signed by a Verification Service Provider (VSP) using XML Signature
 in "W3C.CR-xmldsig-core2-20120124".
 </t>
 
 <t>
-Signed Code, which is described in "verisign_epp-extension_verificationcode", 
+Signed Code, which is described in <xref target="I-D.gould-eppext-verificationcode"/>, 
 is the XML Signature format of the Verification Code.
 </t>	
 
 <t>
-Encoded Signed Code,  which is described in "verisign_epp-extension_verificationcode", 
+Encoded Signed Code,  which is described in <xref target="I-D.gould-eppext-verificationcode"/>, 
 is the "base64" encoded XML Signature format of the Verification Code.
 </t>		
 <t>
-Prohibited Name(PN),TBD.
+Prohibited Name(PN), is a domain label that is prohibited from registration.
 </t>
 <t>
-Reserved Name(RN),TBD.
+Restricted Name(RN), is a domain label that is restricted from registration.  Additional 
+information is needed during Domain Name Verification (DMV) to authorize the registration of 
+a Restricted Name.
 </t>	
           </list>          
       </t>
@@ -216,9 +221,8 @@ Reserved Name(RN),TBD.
           <list style="symbols">
 		  <t>
 		  pendingCompliant.  The object verification is not complete and 
-		  is pending complete.  
-		  Please refer to section 4.3.  Offline Review of Requested Actions
-		  (reference) for details on handling offline review of of 
+		  is pending completion.  
+		  Please refer to <xref target="offlineReview"/> for details on handling offline review of  
 		  NV objects with the pendingComplaint status.
 		  </t>
 		  <t>
@@ -429,8 +433,8 @@ reason.
                <t>
    A &lt;nv:code&gt; element that contains the Verification Code Token value.
    An "type" attribute MUST be used to identify the type of the query(Signed Code or Input Data).
-   If the type is "signedCode",the response of the server MUST be the Signed Code of the verification code.
-  If the type is "input",the response of the server MUST be the verification input data and the verification status.
+   If the type is "signedCode", the successful response of the server MUST be the Signed Code of the verification code.
+  If the type is "input", the successful response of the server MUST be the verification input data and the verification status.
                </t>      
 <t>
 An OPTIONAL &lt;nv:authInfo&gt; element that contains authorization
@@ -515,11 +519,11 @@ the Signed Code Form that contains the following child elements:
       current status associated with the NV.
 	</t> 
 <t>
-A &lt;verificationCode:encodedSignedCode&gt; element include:
+A &lt;nv:encodedSignedCode&gt; element include:
    <list style="symbols">
 <t>
 A &lt;verificationCode:code&gt;element that is an "base64" encoded form of the digitally signed
-&lt;verificationCode:signedCode&gt;.
+&lt;verificationCode:signedCode&gt; as defined in <xref target="I-D.gould-eppext-verificationcode"/>.
 				</t>
                </list>  
 </t>			   
@@ -634,7 +638,7 @@ The &lt;nv:dnv&gt; element is used for a DNV object and contains the following c
    A &lt;nv:name&gt; element that contains the label of the domain.
    </t>
    <t>
-   An OPTIONAL &lt;nv:rnvCode&gt; element containing the Verification Code Token value of a RNV object used for verification of a Reserved Name.  
+   An OPTIONAL &lt;nv:rnvCode&gt; element containing the Verification Code Token value of a RNV object used for verification of a Restricted Name.  
     </t>
    </list>
    </t>	
@@ -821,7 +825,7 @@ The &lt;nv:dnv&gt; element is used for a DNV object and contains the following c
    A &lt;nv:name&gt; element that contains the label of the domain.
    </t>
    <t>
-    An OPTIONAL &lt;nv:rnvCode&gt; element containing the Verification Code Token value of a RNV object used for verification of a Reserved Name. 
+    An OPTIONAL &lt;nv:rnvCode&gt; element containing the Verification Code Token value of a RNV object used for verification of a Restricted Name. 
    </t>
    </list>
    </t>
@@ -958,12 +962,12 @@ C:</epp>
 A  &lt;nv:crDate&gt; element that contains the date and time of nv object creation.
 </t> 
 <t>
-A &lt;verificationCode:encodedSignedCode&gt; element include:
+A &lt;nv:encodedSignedCode&gt; element include:
  
    <list style="symbols">
 <t>
 A &lt;verificationCode:code&gt;element that is an "base64" encoded form of the digitally signed
-&lt;verificationCode:signedCode&gt;.
+&lt;verificationCode:signedCode&gt; as defined in <xref target="I-D.gould-eppext-verificationcode"/>.
 				</t>
                </list>  
 </t>
@@ -1201,7 +1205,7 @@ S:</epp>
       </figure> 
 </section>	
       </section>
-	  <section  title="Offline Review of Requested Actions">
+	  <section  anchor="offlineReview" title="Offline Review of Requested Actions">
 	  <t>
    Commands are processed by a server in the order they are received
    from a client.  Though an immediate response confirming receipt and
@@ -1781,7 +1785,9 @@ End of schema.
 			&RFC2119;
 			&RFC3688;				
 			&RFC5730;
-         &RFC7451;      
+         &RFC7451;   
+         &I-D.gould-eppext-verificationcode;
+         
 	  <reference anchor="W3C.REC-xml-20040204"
                  target="http://www.w3.org/TR/2004/REC-xml-20040204">
         <front>


### PR DESCRIPTION
Kevin, I reviewed the draft in detail, made some changes that included: 
1. Reference to draft-gould-eppext-verificationcode
2. Change name of the draft to draft-xie-eppext-nv-mapping.  The version number of the draft can be defined using the docName attribute of the <rfc> element.
3. Added some text specifying that the verification meets the requirements in China.
4. Added text to the definition of Prohibited Name and Restricted Name.
5. Other small corrections.
